### PR TITLE
add CI job to test against curves repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,3 +159,60 @@ jobs:
         with:
             command: build
             args: --workspace --exclude ark-algebra-test-templates --exclude ark-poly-benches --target thumbv6m-none-eabi
+
+  test_against_curves:
+    name: Test against curves
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -Dwarnings
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+    steps:
+      - name: Checkout curves
+        uses: actions/checkout@v2
+        with:
+          repository: arkworks-rs/curves
+    
+      - name: Checkout algebra
+        uses: actions/checkout@v2
+        with:
+          repository: arkworks-rs/algebra
+          path: algebra
+
+      - name: Install Rust (${{ matrix.rust }})
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            algebra/target
+            target
+          key: ${{ runner.os }}-cargo-curves-${{ hashFiles('**/Cargo.lock') }}
+          
+      - name: Patch cargo.toml
+        run: |
+          echo                                                                             >> Cargo.toml
+          echo      "[patch.'https://github.com/arkworks-rs/algebra']"                     >> Cargo.toml
+          echo      "ark-ff = { path = 'algebra/ff' }"                                     >> Cargo.toml
+          echo      "ark-serialize = { path = 'algebra/serialize' }"                       >> Cargo.toml
+          echo      "ark-ff-macros = { path = 'algebra/ff-macros' }"                       >> Cargo.toml
+          echo      "ark-ff-asm = { path = 'algebra/ff-asm' }"                             >> Cargo.toml
+          echo      "ark-ec = { path = 'algebra/ec' }"                                     >> Cargo.toml
+          echo      "ark-algebra-test-templates = { path = 'algebra/test-templates' }"     >> Cargo.toml
+        
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+            command: test
+            args: "--workspace \
+                   --all-features \
+                   --exclude curve-benches"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #34

Add new CI job `test_against_curves` which does the following steps (as per issue description) 
- Clone `curves` repo
- Clone `algebra` repo
- Patch curves `Cargo.toml` to force the dependency tree to use the local version of the algebra crates.
- Run all tests in `curves`

### Additional Notes
Running all the tests for curves taken around 22 min which leads to an increase of CI runtime from 10 min to 25 min on average.
But if an additional 15min can prevent merging changes that break downstream, I'd say it's well spent

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests 
- [ ] Updated relevant documentation in the code 
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` 
- [x] Re-reviewed `Files changed` in the Github PR explorer
